### PR TITLE
Not ignoring the callback anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,10 +238,14 @@ module.exports = {
 				{
 					var ctx = awsContext();
 					var currentItem = sequence[sequenceIndex];
-					
+
 					var request = currentItem.request;
 					request.session.attributes = attributes || {};
-					handler(request, ctx, undefined, true);
+					var callback = function(err, result) {
+						if (err) return ctx.fail(err);
+						return ctx.succeed(result);
+					}
+					handler(request, ctx, callback, true);
 
 					var requestType = request.request.type;
 					if (requestType == "IntentRequest") requestType = request.request.intent.name;
@@ -253,7 +257,7 @@ module.exports = {
 
 							var actualSay = response.response.outputSpeech ? response.response.outputSpeech.ssml : undefined;
 							var actualReprompt = response.response.reprompt ? response.response.reprompt.outputSpeech.ssml : undefined;
-							
+
 							// check the returned speech
 							if (currentItem.says !== undefined)
 							{
@@ -374,7 +378,7 @@ module.exports = {
 
 		// the message has information that should be displayed by the test runner
 		data.generatedMessage = false;
-		
+
 		data.name = "AssertionError";
 		throw new AssertionError(message, data);
 	},


### PR DESCRIPTION
When using the new 4.3 lambda runtime it's recommended to use the callback, however alexa-skill-test-framework was passing `undefined` as the callback

This change makes it so code that relies on the callback will work