### PR TITLE
Prevent slot param value modification

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,15 +198,17 @@ module.exports = {
 	/**
 	 * Generates an intent request object.
 	 * @param {string} intentName The name of the intent to call.
-	 * @param {object} slots Slot data to call the intent with.
+	 * @param {object} requestSlots Slot data to call the intent with.
 	 * @param {string} locale Optional locale to use. If not specified, uses the locale specified by `setLocale`.
 	 */
-	getIntentRequest: function (intentName, slots, locale) {
+	getIntentRequest: function (intentName, requestSlots, locale) {
 		'use strict';
-		if (!slots) {
+		var slots;
+		if (!requestSlots) {
 			slots = {};
 		}
 		else {
+			slots = Object.create(requestSlots);
 			for (var key in slots) {
 				slots[key] = {name: key, value: slots[key]};
 			}

--- a/index.js
+++ b/index.js
@@ -198,19 +198,19 @@ module.exports = {
 	/**
 	 * Generates an intent request object.
 	 * @param {string} intentName The name of the intent to call.
-	 * @param {object} requestSlots Slot data to call the intent with.
+	 * @param {object} slots Slot data to call the intent with.
 	 * @param {string} locale Optional locale to use. If not specified, uses the locale specified by `setLocale`.
 	 */
-	getIntentRequest: function (intentName, requestSlots, locale) {
+	getIntentRequest: function (intentName, slots, locale) {
 		'use strict';
-		var slots;
-		if (!requestSlots) {
-			slots = {};
+		var requestSlots;
+		if (!slots) {
+			requestSlots = {};
 		}
 		else {
-			slots = JSON.parse(JSON.stringify(requestSlots));
-			for (var key in slots) {
-				slots[key] = {name: key, value: slots[key]};
+			requestSlots = JSON.parse(JSON.stringify(slots));
+			for (var key in requestSlots) {
+				requestSlots[key] = {name: key, value: requestSlots[key]};
 			}
 		}
 		return {
@@ -222,7 +222,7 @@ module.exports = {
 				"requestId": "EdwRequestId." + uuid.v4(),
 				"timestamp": new Date().toISOString(),
 				"locale": locale || this.locale,
-				"intent": {"name": intentName, "slots": slots}
+				"intent": {"name": intentName, "slots": requestSlots}
 			},
 		};
 	},

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ module.exports = {
 			slots = {};
 		}
 		else {
-			slots = Object.create(requestSlots);
+			slots = JSON.parse(JSON.stringify(requestSlots));
 			for (var key in slots) {
 				slots[key] = {name: key, value: slots[key]};
 			}


### PR DESCRIPTION
Hi,

I was using your framework and ran into a situation I could not understand at first and I think this PR solve it. Let's say we have this test

```javascript
describe('My Intent', () => {
  const mySlots = {
    place: 'Chicago',
  };

  describe('Some test', () => {
    alexaTest.test([
      {
        request: alexaTest.getIntentRequest('MyCustomIntent', mySlots),
      }
    ]);
  });

  describe('Some other test', () => {
    alexaTest.test([
      {
        request: alexaTest.getIntentRequest('MyCustomIntent', mySlots),
      }
    ]);
  });

  describe('One more', () => {
    alexaTest.test([
      {
        request: alexaTest.getIntentRequest('MyCustomIntent', mySlots),
      }
    ]);
  });
});
```

The tests will fail because the code in the `getIntentRequest` method is modifying the slot param, so also it modifies the value of the variable `mySlot` in the test above resulting in something like this:

```javascript
{
  name: 'place',
  value: {
    name: 'place',
    value: 'Chicago'
  }
}
```


This PR is to avoid this side effect