### PR TITLE
Fix test npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "scripts": {
-    "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha 'examples/**/*-tests.js' --slow 200"
+    "test": "eslint index.js && mocha --recursive examples/**/*-tests.js --slow 200"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
I was having trouble running the npm script to test a PR I´ve just sent to you guys.

First the linting ran great but the testing with mocha did not. I removed the `node_modules/.bin/` part in the script and that solved the issue but then mocha could not match any test with the `examples/**/*-tests.js` pattern so I added the `--recursive` flag and removed the single quotes around the pattern. That solved all the issues and the test were all green :smile: 