### PR TITLE
Support standard cards and testing for matching card content/text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ Tests the skill with a sequence of requests and expected responses. This method 
   * `confirmsIntent`: Optional Boolean. Tests that the response asks Alexa to confirm the intent.
   * `hasAttributes`: Optional Object. Tests that the response contains the given attributes and values. Values can be strings or functions testing the value.
   * `hasCardTitle`: Optional String. Tests that the card sent by the response has the title specified.
-  * `hasCardContent`: Optional String. Tests that the card sent by the response has the title specified.
+	* `hasCardContent`: Optional String. Tests that the card sent by the response is a simple card and has the content specified.
+	* `hasCardContentLike`: Optional String. Tests that the card sent by the response is a simple card and contains the content specified.
+	* `hasCardText`: Optional String. Tests that the card sent by the response is a standard card and has the text specified.
+	* `hasCardTextLike`: Optional String. Tests that the card sent by the response is a standard card and contains the text specified.
+	* `hasSmallImageUrlLike`: Optional String. Tests that the card sent by the response is a standard card and has a small image URL containing the string specified.
+	* `hasLargeImageUrlLike`: Optional String. Tests that the card sent by the response is a standard card and has a large image URL containing the string specified.
   * `withStoredAttributes`: Optional Object. The attributes to initialize the handler with. Used with DynamoDB mock
   * `storesAttributes`: Optional Object. Tests that the given attributes were stored in the DynamoDB. Values can be strings or functions testing the value.
   * `playsStream`: Optional Object. Tests that the AudioPlayer is used to play a stream.

--- a/index.js
+++ b/index.js
@@ -622,10 +622,9 @@ module.exports = {
 							if (currentItem.hasCardContent) {
 								if (!response.response.card) {
 									context.assert({message: "the response did not contain a card"});
+								} else if (response.response.card.type !== "Simple") {
+									context.assert({ message: "the card in the response was not a simple card" });
 								} else {
-									if (response.response.card.type !== 'Simple') {
-										context.assert({ message: "the card in the response was not a simple card" });
-									}
 									self._assertStringEqual(context, "cardContent", response.response.card.content, currentItem.hasCardContent);
 								}
 							}
@@ -633,10 +632,9 @@ module.exports = {
 							if (currentItem.hasCardContentLike) {
 								if (!response.response.card) {
 									context.assert({ message: "the response did not contain a card" });
+								} else if (response.response.card.type !== "Simple") {
+									context.assert({ message: "the card in the response was not a simple card" });
 								} else {
-									if (response.response.card.type !== 'Simple') {
-										context.assert({ message: "the card in the response was not a simple card" });
-									}
 									self._assertStringContains(context, "cardContent", response.response.card.content, currentItem.hasCardContentLike);
 								}
 							}
@@ -644,10 +642,9 @@ module.exports = {
 							if (currentItem.hasCardText) {
 								if (!response.response.card) {
 									context.assert({ message: "the response did not contain a card" });
+								} else if (response.response.card.type !== "Standard") {
+									context.assert({ message: "the card in the response was not a standard card" });
 								} else {
-									if (response.response.card.type !== 'Standard') {
-										context.assert({ message: "the card in the response was not a standard card" });
-									}
 									self._assertStringEqual(context, "cardText", response.response.card.text, currentItem.hasCardText);
 								}
 							}
@@ -655,10 +652,9 @@ module.exports = {
 							if (currentItem.hasCardTextLike) {
 								if (!response.response.card) {
 									context.assert({ message: "the response did not contain a card" });
+								} else if (response.response.card.type !== "Standard") {
+									context.assert({ message: "the card in the response was not a standard card" });
 								} else {
-									if (response.response.card.type !== 'Standard') {
-										context.assert({ message: "the card in the response was not a standard card" });
-									}
 									self._assertStringContains(context, "cardText", response.response.card.text, currentItem.hasCardTextLike);
 								}
 							}
@@ -666,13 +662,11 @@ module.exports = {
 							if (currentItem.hasSmallImageUrlLike) {
 								if (!response.response.card) {
 									context.assert({ message: "the response did not contain a card" });
+								} else if (response.response.card.type !== "Standard") {
+									context.assert({ message: "the card in the response was not a standard card" });
+								} else if (!response.response.card.image) {
+									context.assert({ message: "the card in the response did not contain an image" });
 								} else {
-									if (response.response.card.type !== 'Standard') {
-										context.assert({ message: "the card in the response was not a standard card" });
-									}
-									if (!response.response.card.image) {
-										context.assert({ message: "the card in the response did not contain an image" });
-									}
 									self._assertStringContains(context, "smallImageUrl", response.response.card.image.smallImageUrl, currentItem.hasSmallImageUrlLike);
 								}
 							}
@@ -680,13 +674,11 @@ module.exports = {
 							if (currentItem.hasLargeImageUrlLike) {
 								if (!response.response.card) {
 									context.assert({ message: "the response did not contain a card" });
+								} else if (response.response.card.type !== "Standard") {
+									context.assert({ message: "the card in the response was not a standard card" });
+								} else if (!response.response.card.image) {
+									context.assert({ message: "the card in the response did not contain an image" });
 								} else {
-									if (response.response.card.type !== 'Standard') {
-										context.assert({ message: "the card in the response was not a standard card" });
-									}
-									if (!response.response.card.image) {
-										context.assert({ message: "the card in the response did not contain an image" });
-									}
 									self._assertStringContains(context, "largeImageUrl", response.response.card.image.largeImageUrl, currentItem.hasLargeImageUrlLike);
 								}
 							}

--- a/index.js
+++ b/index.js
@@ -433,7 +433,12 @@ module.exports = {
 	 * `confirmsIntent`: Optional Boolean. Tests that the response asks Alexa to confirm the intent.
 	 * `hasAttributes`: Optional Object. Tests that the response contains the given attributes and values. Values can be strings or functions testing the value.
 	 * `hasCardTitle`: Optional String. Tests that the card sent by the response has the title specified.
-	 * `hasCardContent`: Optional String. Tests that the card sent by the response has the title specified.
+	 * `hasCardContent`: Optional String. Tests that the card sent by the response is a simple card and has the content specified.
+	 * `hasCardContentLike`: Optional String. Tests that the card sent by the response is a simple card and contains the content specified.
+	 * `hasCardText`: Optional String. Tests that the card sent by the response is a standard card and has the text specified.
+	 * `hasCardTextLike`: Optional String. Tests that the card sent by the response is a standard card and contains the text specified.
+	 * `hasSmallImageUrlLike`: Optional String. Tests that the card sent by the response is a standard card and has a small image URL containing the string specified.
+	 * `hasLargeImageUrlLike`: Optional String. Tests that the card sent by the response is a standard card and has a large image URL containing the string specified.
 	 * `withStoredAttributes`: Optional Object. The attributes to initialize the handler with. Used with DynamoDB mock. Values can be strings or functions testing the value.
 	 * `storesAttributes`: Optional Object. Tests that the given attributes were stored in the DynamoDB.
 	 * `playsStream`: Optional Object. Tests that the AudioPlayer is used to play a stream.
@@ -618,10 +623,74 @@ module.exports = {
 								if (!response.response.card) {
 									context.assert({message: "the response did not contain a card"});
 								} else {
+									if (response.response.card.type !== 'Simple') {
+										context.assert({ message: "the card in the response was not a simple card" });
+									}
 									self._assertStringEqual(context, "cardContent", response.response.card.content, currentItem.hasCardContent);
 								}
 							}
-							
+
+							if (currentItem.hasCardContentLike) {
+								if (!response.response.card) {
+									context.assert({ message: "the response did not contain a card" });
+								} else {
+									if (response.response.card.type !== 'Simple') {
+										context.assert({ message: "the card in the response was not a simple card" });
+									}
+									self._assertStringContains(context, "cardContent", response.response.card.content, currentItem.hasCardContentLike);
+								}
+							}
+
+							if (currentItem.hasCardText) {
+								if (!response.response.card) {
+									context.assert({ message: "the response did not contain a card" });
+								} else {
+									if (response.response.card.type !== 'Standard') {
+										context.assert({ message: "the card in the response was not a standard card" });
+									}
+									self._assertStringEqual(context, "cardText", response.response.card.text, currentItem.hasCardText);
+								}
+							}
+
+							if (currentItem.hasCardTextLike) {
+								if (!response.response.card) {
+									context.assert({ message: "the response did not contain a card" });
+								} else {
+									if (response.response.card.type !== 'Standard') {
+										context.assert({ message: "the card in the response was not a standard card" });
+									}
+									self._assertStringContains(context, "cardText", response.response.card.text, currentItem.hasCardTextLike);
+								}
+							}
+
+							if (currentItem.hasSmallImageUrlLike) {
+								if (!response.response.card) {
+									context.assert({ message: "the response did not contain a card" });
+								} else {
+									if (response.response.card.type !== 'Standard') {
+										context.assert({ message: "the card in the response was not a standard card" });
+									}
+									if (!response.response.card.image) {
+										context.assert({ message: "the card in the response did not contain an image" });
+									}
+									self._assertStringContains(context, "smallImageUrl", response.response.card.image.smallImageUrl, currentItem.hasSmallImageUrlLike);
+								}
+							}
+
+							if (currentItem.hasLargeImageUrlLike) {
+								if (!response.response.card) {
+									context.assert({ message: "the response did not contain a card" });
+								} else {
+									if (response.response.card.type !== 'Standard') {
+										context.assert({ message: "the card in the response was not a standard card" });
+									}
+									if (!response.response.card.image) {
+										context.assert({ message: "the card in the response did not contain an image" });
+									}
+									self._assertStringContains(context, "largeImageUrl", response.response.card.image.largeImageUrl, currentItem.hasLargeImageUrlLike);
+								}
+							}
+
 							// check the shouldEndSession flag
 							if (currentItem.shouldEndSession === true && response.response.shouldEndSession === false) {
 								context.assert(


### PR DESCRIPTION
* Standard cards can now be tested for text, smallImageUrl and largeImageUrl.
* Card content/text can now be tested for contained string using hasCardContentLike/hasCardTextLike.