### PR TITLE
Flag to add session attributes on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Tests the skill with a sequence of requests and expected responses. This method 
   * `hasCardContent`: Optional String. Tests that the card sent by the response has the title specified.
   * `withStoredAttributes`: Optional Object. The attributes to initialize the handler with. Used with DynamoDB mock
   * `storesAttributes`: Optional Object. Tests that the given attributes were stored in the DynamoDB. Values can be strings or functions testing the value.
+  * `withSessionAttributes`: Optional Object. The session attributes to initialize the an intent request with. Values can be strings, booleans, or integers.
   * `playsStream`: Optional Object. Tests that the AudioPlayer is used to play a stream.
   * `stopsStream`: Optional Boolean. Tests that the AudioPlayer is stopped.
   * `clearsQueue`: Optional String. Tests that the AudioPlayer clears the queue with the given clear behavior.

--- a/index.js
+++ b/index.js
@@ -454,8 +454,13 @@ module.exports = {
 					// adds values from withSessionAttributes to the session
 					if (currentItem.withSessionAttributes) {
 						var session = request.session.attributes;
-						for(var x in currentItem.withSessionAttributes) session[x] = currentItem.withSessionAttributes[x];
-					};
+
+						for (var newAttribute in currentItem.withSessionAttributes) {
+							if (typeof session[`${newAttribute}`] === "undefined") {
+								session[`${newAttribute}`] = currentItem.withSessionAttributes[`${newAttribute}`];
+							}
+						}
+					}
 					
 					var requestType = request.request.type;
 					if (requestType === "IntentRequest") {

--- a/index.js
+++ b/index.js
@@ -404,6 +404,7 @@ module.exports = {
 	 * `hasCardTitle`: Optional String. Tests that the card sent by the response has the title specified.
 	 * `hasCardContent`: Optional String. Tests that the card sent by the response has the title specified.
 	 * `withStoredAttributes`: Optional Object. The attributes to initialize the handler with. Used with DynamoDB mock. Values can be strings or functions testing the value.
+	 * `withSessionAttributes`: Optional Object. The session attributes to initialize the an intent request with. Values can be strings, booleans, or integers.
 	 * `storesAttributes`: Optional Object. Tests that the given attributes were stored in the DynamoDB.
 	 * `playsStream`: Optional Object. Tests that the AudioPlayer is used to play a stream.
 	 * `stopsStream`: Optional Boolean. Tests that the AudioPlayer is stopped.
@@ -448,6 +449,12 @@ module.exports = {
 							return ctx.fail(err);
 						}
 						return ctx.succeed(result);
+					};
+
+					// adds values from withSessionAttributes to the session
+					if (currentItem.withSessionAttributes) {
+						var session = request.session.attributes;
+						for(var x in currentItem.withSessionAttributes) session[x] = currentItem.withSessionAttributes[x];
 					};
 					
 					var requestType = request.request.type;

--- a/index.js
+++ b/index.js
@@ -456,8 +456,8 @@ module.exports = {
 						var session = request.session.attributes;
 
 						for (var newAttribute in currentItem.withSessionAttributes) {
-							if (typeof session[`${newAttribute}`] === "undefined") {
-								session[`${newAttribute}`] = currentItem.withSessionAttributes[`${newAttribute}`];
+							if (!session[newAttribute]) {
+								session[newAttribute] = currentItem.withSessionAttributes[newAttribute];
 							}
 						}
 					}


### PR DESCRIPTION
Adds the `withSessionAttributes` property that allows a request to be initialized with the provided attributes object.